### PR TITLE
Added Patches for: CTX201078 - CVE-2015-3456 - VENOM

### DIFF
--- a/patches/boston
+++ b/patches/boston
@@ -18,3 +18,5 @@ XS60E026|9483abb3-33d3-41cd-ac98-3e4d42e19a5f|support.citrix.com/servlet/KbServl
 XS60E027|8d5824a5-32e5-4cb1-9d12-c48dd2f55070|support.citrix.com/servlet/KbServlet/download/33643-102-696861/XS60E027.zip|support.citrix.com/article/CTX136477
 XS60E028|6820f60b-d344-4c60-9c51-c0bc85ac98c8|support.citrix.com/servlet/KbServlet/download/34299-102-697726/XS60E028.zip|support.citrix.com/article/CTX137484
 XS60E029|54e5c392-1a00-4624-bda5-38f0f312a74a|support.citrix.com/servlet/KbServlet/download/34483-102-703527/XS60E029.zip|support.citrix.com/article/CTX137672
+XS60E047|c108ef87-12f8-4e7d-81b8-78f06a9474da|downloadns.citrix.com.edgesuite.net/akdlm/10560/XS60E047.zip|support.citrix.com/article/CTX201078
+

--- a/patches/clearwater
+++ b/patches/clearwater
@@ -11,3 +11,5 @@ XS62ESP1014|4fc82e62-b938-407d-a2c6-68c8922f3ec2|downloadns.citrix.com.edgesuite
 XS62ESP1015|f4f66d0a-d408-446e-a014-8e793baccb07|downloadns.citrix.com.edgesuite.net/akdlm/10128/XS62ESP1015.zip|support.citrix.com/article/CTX141717
 XS62ESP1016|55444a02-4d97-4d6d-b076-ddbe8697244b|downloadns.citrix.com.edgesuite.net/akdlm/10174/XS62ESP1016.zip|support.citrix.com/article/CTX141779
 XS62ESP1017|902607f2-6186-464b-bcb8-86559602ab58|downloadns.citrix.com.edgesuite.net/akdlm/10193/XS62ESP1017.zip|support.citrix.com/article/CTX142012
+XS62ESP1025|f359f49e-0c5a-4e38-8da0-9f550dab5f64|downloadns.citrix.com.edgesuite.net/akdlm/10564/XS62ESP1025.zip|support.citrix.com/article/CTX201078
+

--- a/patches/creedence
+++ b/patches/creedence
@@ -1,1 +1,3 @@
 XS65ESP1|7f2e4a3a-4098-4a71-84ff-b0ba919723c7|downloadns.citrix.com.edgesuite.net/akdlm/10340/XS65ESP1.zip|support.citrix.com/article/CTX142355
+XS65ESP1002|2e1518ec-e536-4ef7-a106-6f50ce56da5a|downloadns.citrix.com.edgesuite.net/10566/XS65ESP1002.zip|support.citrix.com/article/CTX201078
+

--- a/patches/sanibel
+++ b/patches/sanibel
@@ -17,3 +17,5 @@ XS602E020|a38a5539-f982-4d95-8fc7-3b5130151919|support.citrix.com/servlet/KbServ
 XS602E021|8ce9a668-a254-4693-8e41-e3c18e065341|support.citrix.com/servlet/KbServlet/download/33645-102-696863/XS602E021.zip|support.citrix.com/article/CTX136479
 XS602E022|fa8224f5-d66e-42d2-bbd9-c3cfab12c457|support.citrix.com/servlet/KbServlet/download/34298-102-697725/XS602E022.zip|support.citrix.com/article/CTX137486
 XS602E023|29c9b53e-b29b-47de-8cc5-43e91f0a506b|support.citrix.com/servlet/KbServlet/download/34482-102-703526/XS602E023.zip|support.citrix.com/article/CTX137673
+XS602E043|a415c6e3-fd98-44c4-bc9a-b7958273f3e4|downloadns.citrix.com.edgesuite.net/akdlm/10561/XS602E043.zip|support.citrix.com/article/CTX201078
+XS602ECC019|e2dc0ac5-7406-4387-a3f6-b6b38611df19|downloadns.citrix.com.edgesuite.net/akdlm/10562/XS602ECC019.zip|support.citrix.com/article/CTX201078

--- a/patches/tampa
+++ b/patches/tampa
@@ -10,3 +10,5 @@ XS61E014|b285594e-85d2-4dcc-abe5-7dcce8b000b5|support.citrix.com/servlet/KbServl
 XS61E017|e732191c-c70d-4203-83ca-59119d131a2c|support.citrix.com/servlet/KbServlet/download/33951-102-697178/XS61E017.zip|support.citrix.com/article/CTX137168
 XS61E019|44290145-235f-4271-9d8e-9807e14e21f4|support.citrix.com/servlet/KbServlet/download/34297-102-697724/XS61E019.zip|support.citrix.com/article/CTX137487
 XS61E022|1ac72bbf-cb20-4d48-b1ed-0f9230aed7af|support.citrix.com/servlet/KbServlet/download/34480-102-703524/XS61E022.zip|support.citrix.com/article/CTX137675
+XS61E052|cb286cca-f2ce-4856-965a-0c45a0c2f89c|downloadns.citrix.com.edgesuite.net/akdlm/10563/XS61E052.zip|support.citrix.com/article/CTX201078
+


### PR DESCRIPTION
I added the patch sources for the latest VENOM Bug. This has been succesfully tested on XS 6.5. It has not been tested on versions below 6.5.